### PR TITLE
Fix issue due to NumPy API change

### DIFF
--- a/prepper/exportable.py
+++ b/prepper/exportable.py
@@ -225,7 +225,7 @@ class ExportableClassMixin(metaclass=ABCMeta):
             file.close()
             with warnings.catch_warnings():
                 warnings.simplefilter("ignore", category=FutureWarning)
-                warnings.simplefilter("ignore", category=np.VisibleDeprecationWarning)
+                warnings.simplefilter("ignore", category=np.exceptions.VisibleDeprecationWarning)
                 self._write_hdf5_contents(
                     Path(temp_file), group="/", existing_groups={}
                 )


### PR DESCRIPTION
This PR fixes an issue that occurs with `numpy >= 2`, where `np.VisibleDeprecationWarning` is no longer directly accessible.

Instead, it should be accessed with `np.exceptions.VisibleDeprecationWarning`.

------

*Notes for @varchasgopalaswamy:* 
- *This was causing an issue on the Linux runner for `lotus` CI pipelines on some new test cases.*
- *Does NumPy still need to be pinned to `<2` in `prepper`?*